### PR TITLE
Update cantata link, add MAENMPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,11 @@ Client developers should create a standard for common sticker names, to ensure i
 
 ## Clients with sticker support
 
-- [Cantata](https://github.com/CDrummond/cantata)
+- [Cantata](https://github.com/nullobsi/cantata)
 - [mpdev](https://github.com/mbhangui/mpdev)
 - [myMPD](https://github.com/jcorporation/myMPD)
 
 ### Cantata
-
-Archived, is there any maintained fork?
 
 | Sticker | Format | Description |
 | ------- | ------ | ----------- |

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Client developers should create a standard for common sticker names, to ensure i
 - [Cantata](https://github.com/nullobsi/cantata)
 - [mpdev](https://github.com/mbhangui/mpdev)
 - [myMPD](https://github.com/jcorporation/myMPD)
+- [MAENMPC](https://github.com/m7a/lo-maenmpc)
 
 ### Cantata
 
@@ -41,3 +42,10 @@ Client developers should create a standard for common sticker names, to ensure i
 | playCount | Integer | How often the song was played |
 | rating | Integer in range 0-10 | 5 Stars rating |
 | skipCount | Integer | How often the song was skipped |
+
+### MAENMPC
+
+| Sticker | Format | Description |
+| ------- | ------ | ----------- |
+| playCount | Integer | How often the song was played (limited support) |
+| rating | Integer in range 0-10 | 5 Stars rating |


### PR DESCRIPTION
Hello,

I have identified a recently updated Catnata fork and would propse it to be linked from the table here.

Also, I propse to add my own client MAENMPC to the stickers table. Like some of the others, it supports the stars-based rating. playCount is only supported under certain circumstances, but I suggest to list it anyways as to establish that this is the recommended name to use for play count tracking?

Thanks in advance and Kind regards
Linux-Fan (@m7a)