### PR TITLE
add rmpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Client developers should create a standard for common sticker names, to ensure i
 - [mpdev](https://github.com/mbhangui/mpdev)
 - [myMPD](https://github.com/jcorporation/myMPD)
 - [MAENMPC](https://github.com/m7a/lo-maenmpc)
+- [rmpc](https://github.com/mierak/rmpc)
 
 ### Cantata
 
@@ -49,3 +50,11 @@ Client developers should create a standard for common sticker names, to ensure i
 | ------- | ------ | ----------- |
 | playCount | Integer | How often the song was played (limited support) |
 | rating | Integer in range 0-10 | 5 Stars rating |
+
+### rmpc
+
+| Sticker | Format | Description |
+| ------- | ------ | ----------- |
+| playCount | Integer | How often the song was played (has to be configured by user) |
+| rating | Integer in range 0-10 | Rating of the song |
+| like | Integer in range 0-2 |0 - dislike, 1 - neutral, 2 - like |


### PR DESCRIPTION
Hi! Thanks for this repo and for the attempt to standardize these. I have used it as a reference when implementing [rating](https://github.com/mierak/rmpc/pull/633) and [like](https://github.com/mierak/rmpc/pull/641) functionality in [rmpc](https://github.com/mierak/rmpc).

Rmpc now uses the mentioned stickers for its functionality so I am adding the client to the list if you don't mind. The users of rmpc have some freedom with the stickers (they can for example override the rating range) but the defaults will always be as mentioned and strongly preferred.