### PR TITLE
Album stickers: Specify syntax more strictly

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Stickers for songs are attached to the song uri and are lost if the file was ren
 
 ### Stickers for albums
 
-The best way to add maintain stickers for albums is to use a filter expression and NOT the album tag. The album tag is not uniq across different artists, e. g. the album name "Best Of" is only stored once in the MPD database but can be the name of more than one album in the database.
+The best way to add maintain stickers for albums is to use a filter expression and NOT the album tag. The album tag is not unique across different artists, e. g. the album name "Best Of" is only stored once in the MPD database but can be the name of more than one album in the database.
 
 The recommended filter is:
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ The recommended filter is:
 ``((AlbumArtist == "<AlbumArtist>") AND (Album == "<Album>") AND (Date == "<Date>"))``
 
 - AlbumArtist falls back to Album (MPD default)
-- Date is optional, but recommended to differentiate various album released from one artist.
+- Date must be present in the filter if a Date metadata field exists for the album
+- The syntax of the filter must follow exactly this convention. E.g. the order of the comparisons, spacing and quotation must match. Otherwise different clients may not be able to find each other's album stickers.
 
 ## Clients with sticker support
 


### PR DESCRIPTION
Follow-up from: <https://github.com/jcorporation/myMPD/discussions/1526>

MPD supports attaching stickers to filters, providing a flexible means to define
stickers about arbitrary subsets of the database. This mechanism can be
instantiated to attach stickers to albums.

The initial specification for such stickers declared the “Date” field as
a recommended but optional part in the filter.

Upon testing it turns out that when querying stickers, stickers assigned to
filters are only returned if the very same filter syntax is used as was done
when the filter was created. I.e. filters in filter-based stickers work more
like a “string key” into a map rather than a filter object. Among other things,
data from a less specific filter is not returned when querying a a more specific
filter nor vice-versa.

Having the Date optional would thus establish compatibility only in event that
the client follows the “recommendation” to include it.

This commit proposes a rewording which accounts for this limit by requiring the
Date field to be present in the filter if it is at all available. The idea is
that multiple clients are going to generate the exact same filter syntax and
thus become compatible e.g. wrt. album rating features or similar.