### PR TITLE
add lastPlayed to rmpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,4 @@ The recommended filter is:
 | playCount | Integer | How often the song was played (has to be configured by user) |
 | rating | Integer in range 0-10 | Rating of the song |
 | like | Integer in range 0-2 |0 - dislike, 1 - neutral, 2 - like |
+| lastPlayed | Unix timestamp | Last played time of song |

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The recommended filter is:
 | mpdfav | | | | | | * | |
 | MPDroid | | | | | | * | |
 | myMPD | x | x | x | x | x | x | x |
-| rmpc | | | | x | x | x | |
+| rmpc | | x | | x | x | x | |
 
 - `x`: Support
 - `*`: Incompatible support


### PR DESCRIPTION
Hi!

I have added support for lastPlayed sticker to [rmpc](https://rmpc.mierak.dev/configuration/stickers/) so updating the table here.

And also a bonus question, I am creating [rmpcd](https://rmpc.mierak.dev/rmpcd/), a companion client to rmpc. It is a recommended way to track the lastPlayed stickers with this [plugin](https://github.com/rmpc-org/rmpcd-lastplayed) for example. Would you like to track rmpcd in this repo as well or is it too loosy since basicaly nothing is hardcoded in there? I am fine with either.